### PR TITLE
I've fixed a bug that was preventing matchingValues from working with multiple parameters

### DIFF
--- a/spec/jasmine-signalsSpec.js
+++ b/spec/jasmine-signalsSpec.js
@@ -113,6 +113,19 @@ describe('jasmine-signals', function() {
 			expect(signalSpy).toHaveBeenDispatched(2);
 		});
 
+
+        it('should spyOnSignal matching multiple values', function() {
+            var signal = new signals.Signal();
+            var signalSpy = spyOnSignal(signal).matchingValues(1,2);
+
+            signal.dispatch(1,2);
+            signal.dispatch(5);
+            signal.dispatch(1,2);
+
+            expect(signalSpy).toHaveBeenDispatched();
+            expect(signalSpy).toHaveBeenDispatched(2);
+        });
+
 	});
 
 });

--- a/src/jasmine-signals.js
+++ b/src/jasmine-signals.js
@@ -55,7 +55,8 @@
 			this.signal.add(onSignal, this);
 
 			function onSignal(parameters) {
-				if (this.matcher(parameters)) {
+                //fixes bug which prevented matching on multiple parameters
+                if (this.matcher.apply(this, [].splice.call(arguments, 0))){
 					this.count++;
 				}
 			}


### PR DESCRIPTION
Hi Adam

There was a bug on line 58 of jamine-signals.js which invoked the
matcher using a single parameter which worked fine for single parameter
signals (e.g. signal.dispatch(1)) but fell over for  multiple parameter
signals (e.g. signal.dispatch(1,2)) - I have used matcher.apply with
the arguments array and added a unit test.

Could you add my fix to the master?

Cheers
