### PR TITLE
Improving SignalSpy parity with jasmine Spies

### DIFF
--- a/jasmine-signals.js
+++ b/jasmine-signals.js
@@ -1,7 +1,5 @@
 (function (global) {
-
 	var spies = [];
-	var jasmineEnv = jasmine.getEnv();
 
 	jasmine.signals = {};
 
@@ -26,6 +24,15 @@
 			return '(' + d + ')';
 		}).join('');
 	}
+
+    function getSpy(actual) {
+        if (actual instanceof signals.Signal) {
+            return spies.filter(function spiesForSignal(d) {
+                return d.signal === actual;
+            })[0];
+        }
+        return actual;
+    }
 
     jasmine.signals.matchers = {
         toHaveBeenDispatched: function (util, customEqualityTesters) {
@@ -89,14 +96,6 @@
         }
     };
 
-    function getSpy(actual) {
-        if (actual instanceof signals.Signal) {
-            return spies.filter(function spiesForSignal(d) {
-                return d.signal === actual;
-            })[0];
-        }
-        return actual;
-    }
 
     /*
      * Spy implementation
@@ -142,7 +141,7 @@
             return this;
         };
 
-        namespace.SignalSpy.prototype.andCallThrough = function() {  //TODO: tests
+        namespace.SignalSpy.prototype.andCallThrough = function() {
             this.plan = function() {
                 var planArgs = arguments;
                 this.stop();  //stop spying - remove the spy binding
@@ -155,14 +154,14 @@
             return this;
         };
 
-        namespace.SignalSpy.prototype.andThrow = function(exceptionMsg) {  //TODO: tests
+        namespace.SignalSpy.prototype.andThrow = function(exceptionMsg) {
             this.plan = function() {
                 throw exceptionMsg;
             };
             return this;
         };
 
-        namespace.SignalSpy.prototype.andCallFake = function(fakeFunc) {  //TODO: tests
+        namespace.SignalSpy.prototype.andCallFake = function(fakeFunc) {
             this.plan = fakeFunc;
             return this;
         };
@@ -191,20 +190,22 @@
         spies = [];
     });
 
+    function setGlobals(signals, spyOnSignal) {
+        global['signals'] = signals;
+        global['spyOnSignal'] = spyOnSignal;
+    }
+
     // exports to multiple environments
     if (typeof define === 'function' && define.amd) { // AMD
         define(['signals'], function (amdSignals) {
-            signals = amdSignals;
-            spyOnSignal = jasmine.signals.spyOnSignal;
+            setGlobals(amdSignals, jasmine.signals.spyOnSignal);
             return jasmine.signals.spyOnSignal;
         });
-    } else if (typeof module !== 'undefined' && module.exports) { // node
-        module.exports = jasmine.signals.spyOnSignal;
-    } else { // browser
-        // use string because of Google closure compiler ADVANCED_MODE
-        /*jslint sub: true */
-        global['spyOnSignal'] = jasmine.signals.spyOnSignal;
-        signals = global['signals'];
+    } else {
+        setGlobals(global['signals'], jasmine.signals.spyOnSignal);
+        if (typeof module !== 'undefined' && module.exports) { // node
+            module.exports = jasmine.signals.spyOnSignal;
+        } else { } // browser
     }
 
 } (this));

--- a/jasmine-signals.js
+++ b/jasmine-signals.js
@@ -168,12 +168,12 @@
 
     })(jasmine.signals);
 
-    jasmine.createSignalSpyObj = function(baseName, methodNames) {  //TODO: tests
+    jasmine.createSignalSpyObj = function(methodNames) {
         var obj = {};
         if (!jasmine.isArray_(methodNames) || methodNames.length === 0) {
             throw new Error('createSignalSpyObj requires a non-empty array of method names to create spies for');
         }
-        methodNames.forEach(function(name){
+        methodNames.forEach(function(name) {
             obj[name] = jasmine.signals.spyOnSignal(new signals.Signal());
         });
         return obj;

--- a/jasmine-signalsSpec.js
+++ b/jasmine-signalsSpec.js
@@ -1,5 +1,5 @@
 describe('jasmine-signals', function() {
-	var signal, spy, result;
+	var signal, spy, listenerSpy, result;
 
 	beforeEach(function () {
 		signal = new signals.Signal();
@@ -28,19 +28,112 @@ describe('jasmine-signals', function() {
 		expect(signal.getNumListeners()).toBe(1);
 	});
 
-	it('should unsubscribe from signal on stop', function() {
-		spy.stop();
-
-		expect(signal.getNumListeners()).toBe(0);
-	});
-
 	it('should accept signal in expectations', function () {
 		signal.dispatch();
 
 		expect(signal).toHaveBeenDispatched();
 	});
 
-	describe('toHaveBeenDispatched', function() {
+    it('should halt dispatch before it reaches listeners added before spy invocation', function () {
+        var signal = new signals.Signal();
+        listenerSpy = jasmine.createSpy('listenerSpy');
+        signal.add(listenerSpy);
+        spy = spyOnSignal(signal);
+        signal.dispatch();
+
+        expect(spy).toHaveBeenDispatched();
+        expect(listenerSpy).not.toHaveBeenCalled();
+    });
+
+    it('should halt dispatch before it reaches listeners added after spy invocation', function () {
+        listenerSpy = jasmine.createSpy('listenerSpy');
+        signal.add(listenerSpy);
+        signal.dispatch();
+
+        expect(spy).toHaveBeenDispatched();
+        expect(listenerSpy).not.toHaveBeenCalled();
+    });
+
+    describe('stop', function() {
+        it('should unsubscribe from the signal', function() {
+            spy.stop();
+
+            expect(signal.getNumListeners()).toBe(0);
+        });
+        it('should resume normal dispatch to listeners', function () {
+            listenerSpy = jasmine.createSpy('listenerSpy');
+            signal.add(listenerSpy);
+            spy.stop();
+            signal.dispatch();
+
+            expect(spy).not.toHaveBeenDispatched();
+            expect(listenerSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('andThrow', function() {
+        it('should throw the correct exception', function() {
+            var exceptionMsg = 'test exception';
+            spy.andThrow(exceptionMsg);
+
+            expect(spy).not.toHaveBeenDispatched();
+            expect(signal.dispatch).toThrow(exceptionMsg);
+        });
+        it('should not throw an exception after the spy has been stopped', function () {
+            var exceptionMsg = 'test exception';
+            spy.andThrow(exceptionMsg);
+            spy.stop();
+
+            expect(spy).not.toHaveBeenDispatched();
+            expect(signal.dispatch).not.toThrow(exceptionMsg);
+        });
+    });
+
+    describe('andCallFake', function() {
+        it('should call the mock function on signal dispatch', function() {
+            listenerSpy = jasmine.createSpy('listenerSpy');
+            spy.andCallFake(listenerSpy);
+            signal.dispatch();
+
+            expect(spy).toHaveBeenDispatched();
+            expect(listenerSpy).toHaveBeenCalled();
+        });
+        it('should not call the mock function after the spy has been stopped', function () {
+            listenerSpy = jasmine.createSpy('listenerSpy');
+            spy.andCallFake(listenerSpy);
+            spy.stop();
+            signal.dispatch();
+
+            expect(spy).not.toHaveBeenDispatched();
+            expect(listenerSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('andCallThrough', function() {
+        it('should call through to listeners added before spy invocation', function () {
+            var signal = new signals.Signal();
+            listenerSpy = jasmine.createSpy('listenerSpy');
+            signal.add(listenerSpy);
+            spy = spyOnSignal(signal).andCallThrough();
+            signal.dispatch();
+
+            expect(spy).toHaveBeenDispatched();
+            expect(listenerSpy).toHaveBeenCalled();
+        });
+
+        it('should call through to listeners added after spy invocation', function () {
+            listenerSpy = jasmine.createSpy('listenerSpy');
+            signal.add(listenerSpy);
+            spy.andCallThrough();
+            signal.dispatch();
+
+            expect(spy).toHaveBeenDispatched();
+            expect(listenerSpy).toHaveBeenCalled();
+        });
+    });
+
+
+    describe('toHaveBeenDispatched', function() {
 
 		it('should know if signal dispatched', function() {
 			signal.dispatch();

--- a/jasmine-signalsSpec.js
+++ b/jasmine-signalsSpec.js
@@ -261,5 +261,28 @@ describe('jasmine-signals', function() {
 
 	});
 
+    describe('createSignalSpyObj', function() {
+        var error_msg = 'createSignalSpyObj requires a non-empty array of method names to create spies for';
+
+        it('should throw an error if methodNames is an empty array', function() {
+            expect(function() {
+                jasmine.createSignalSpyObj([]);
+            }).toThrowError(error_msg);
+        });
+        it('should throw an error if methodNames is not an array', function() {
+            expect(function() {
+                jasmine.createSignalSpyObj({});
+            }).toThrowError(error_msg);
+        });
+        it('should return an object of SignalSpies', function() {
+            var methodNames = ['test1', 'test2', 'test3'],
+                spies = jasmine.createSignalSpyObj(methodNames);
+
+            methodNames.forEach(function(spy_name) {
+                expect(spies[spy_name] instanceof jasmine.signals.SignalSpy).toEqual(true);
+            });
+        });
+    });
+
 });
 


### PR DESCRIPTION
I found SignalSpies lacking some of the functionality of standard jasmine Spies, so I put these in with tests.  I implemented createSignalSpyObject which mimics the behaviour of createSpyObject to about as close as I could get without modifying the SignalSpy object to use a baseName.  I also moved a couple of things around to make the code easier to read.
